### PR TITLE
Add dynamic landing page for each country

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,6 +15,9 @@ page '/*.txt', layout: false
 # Proxy pages (http://middlemanapp.com/basics/dynamic-pages/)
 # proxy "/this-page-has-no-template.html", "/template-file.html", locals: {
 #  which_fake_page: "Rendering a fake page with a local variable" }
+data.countries.each do |slug, country|
+  proxy "/#{slug}/index.html", "/country_template.html", :locals => { country: country }
+end
 
 # General configuration
 
@@ -22,6 +25,9 @@ page '/*.txt', layout: false
 configure :development do
   activate :livereload
 end
+
+# Pretty URLs (Directory Indexes)
+activate :directory_indexes
 
 ###
 # Helpers

--- a/data/countries.yml
+++ b/data/countries.yml
@@ -1,0 +1,15 @@
+australia:
+  name_en: Australia
+  name_zh: 澳洲
+  url: https://github.com/taiwanese-work-in/australia/wiki
+  intro: 澳洲人坐擁大量資源、地廣人稀的澳洲，加上英國良好的商業法規所驅使，礦場與觀光正是財富來源的兩大支柱，成就經濟與生活上亦屬世界高度發達國家的澳洲。在多項指數與排名例如生活素質，健康，教育，經濟自由度，公民自由度與政治權利中名列前茅，因而是世界上的遷徙熱點之一，特別是吸引許多鄰近的亞洲移民。
+japan:
+  name_en: Japan
+  name_zh: 日本
+  url: https://github.com/taiwanese-work-in/japan/wiki
+  intro: 自二戰結束後，日本經濟高速增長，躋身先進國家之列，科研能力、工業基礎和製造業技術均在亞洲以至世界位居前茅，同時是當今世界第四大出口國和進口國，是全球國際最富裕、經濟最發達和生活水平最高的國家之一。另因對歷史及傳統文化維護的重視，日本擁有相當完整的藝術及文化產業體系，尤其是影視、流行音樂、動漫、電玩、時尚等娛樂流行產業，在全球化的傳播下，於亞洲乃至於全世界都佔有相當地位。
+singapore:
+  name_en: Singapore
+  name_zh: 新加坡
+  url: https://github.com/taiwanese-work-in/singapore/wiki
+  intro: 新加坡是個多元文化種族的移民國家，並非單一民族國家，也是全球最國際化的國家之一，在國內居住的居民有 38% 為永久居民、拿工作簽證的外勞和拿學生簽證的學生。整個城市在綠化和保潔方面效果顯著，故有花園城市的美稱。

--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -10,6 +10,13 @@
       <li>
         Cover image CC-BY by <a href="https://www.flickr.com/photos/121483302@N02/13490217355/in/photolist-my5TCp-6UyBbM-73xCpe-eeW2Ai-61xGL6-ubHKa9">Mish Sukharev</a>
       </li>
+      <li>
+        各國家介紹詞參考自 wiki
+        <a href="https://zh.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC">日本</a> /
+        <a href="https://zh.wikipedia.org/wiki/%E6%BE%B3%E5%A4%A7%E5%88%A9%E4%BA%9A">澳洲</a> /
+        <a href="https://zh.wikipedia.org/wiki/%E6%96%B0%E5%8A%A0%E5%9D%A1">新加坡</a>
+        條目
+      </li>
     </ul>
   </div>
 

--- a/source/country_template.html.erb
+++ b/source/country_template.html.erb
@@ -1,0 +1,44 @@
+<% content_for(:title, "Taiwanese Work In #{country.name_en}") %>
+
+<div class="container-fluid">
+  <div class="row country-select">
+    <div class="col-md-offset-3 col-md-6">
+        <h2 class="text-muted">Taiwanese Work In <%= country.name_en %></h2>
+        <a href="/"><span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span> 回首頁</a>
+    </div>
+  </div>
+
+  <div class="row main">
+    <div class="col-md-offset-3 col-md-6">
+      <div class="jumbotron">
+        <h1>到<%= country.name_zh %>工作</h1>
+        <p><%= country.intro %></p>
+        <p><a class="btn btn-primary btn-lg" href="<%= country.url %>" role="button">前往<%= country.name_zh %>工作知識庫</a></p>
+      </div>
+    </div>
+
+    <div class="col-md-offset-3 col-md-6">
+      <p class="text-center"><span class="glyphicon glyphicon-plane" aria-hidden="true"></span></p>
+
+      <h4>加入貢獻</h4>
+      <p>
+        歡迎一同編輯知識庫，目前採用 GitHub wiki 系統，部分國家已開放公開任何人編輯；若想提供片段資料但不想整理、編輯，也歡迎開 <a href="https://github.com/taiwanese-work-in/singapore/issues">GitHub issue</a> 提供。
+      </p>
+      <p>若您想要建立尚未列出的國家的知識庫，也歡迎與我們聯絡。</p>
+
+      <p class="text-center"><span class="glyphicon glyphicon-plane" aria-hidden="true"></span></p>
+
+      <div class="panel panel-warning">
+        <div class="panel-heading">
+          <h3 class="panel-title">請按讚並傳給想出國工作的朋友</h3>
+        </div>
+
+        <div class="panel-body">
+          <div class="fb-like" data-href="http://taiwanese-work.in" data-layout="standard" data-action="like" data-show-faces="true" data-share="true"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%= partial "footer" %>
+</div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -2,15 +2,6 @@
 title: Taiwanese Work In
 ---
 
-<div id="fb-root"></div>
-<script>(function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0];
-  if (d.getElementById(id)) return;
-  js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.6&appId=1016219591795157";
-  fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));</script>
-
 <div class="container-fluid">
   <div class="row cover-image">
     <div class="col-md-12">
@@ -25,19 +16,19 @@ title: Taiwanese Work In
     </div>
 
     <div class="col-md-offset-3 col-md-2">
-        <a href="https://github.com/taiwanese-work-in/australia/wiki" class="btn btn-default btn-lg btn-block">
+        <a href="/australia" class="btn btn-default btn-lg btn-block">
           <span class="glyphicon glyphicon-book" aria-hidden="true"></span> Australia
         </a>
     </div>
 
     <div class="col-md-2">
-        <a href="https://github.com/taiwanese-work-in/japan/wiki" class="btn btn-default btn-lg btn-block">
+        <a href="/japan" class="btn btn-default btn-lg btn-block">
           <span class="glyphicon glyphicon-book" aria-hidden="true"></span> Japan
         </a>
     </div>
 
     <div class="col-md-2">
-        <a href="https://github.com/taiwanese-work-in/singapore/wiki" class="btn btn-default btn-lg btn-block">
+        <a href="/singapore" class="btn btn-default btn-lg btn-block">
           <span class="glyphicon glyphicon-book" aria-hidden="true"></span> Singapore
         </a>
     </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -6,7 +6,7 @@
     <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
 
     <!-- Use title if it's in the page YAML frontmatter -->
-    <title><%= current_page.data.title || "Taiwanese Work In" %></title>
+    <title><%= yield_content(:title) || current_page.data.title || "Taiwanese Work In" %></title>
 
     <link href='//fonts.googleapis.com/css?family=Lato:300,400' rel='stylesheet' type='text/css'>
     <link href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css' rel='stylesheet' type='text/css'>
@@ -27,6 +27,15 @@
   </head>
 
   <body class="<%= page_classes %>">
+    <div id="fb-root"></div>
+    <script>(function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.6&appId=1016219591795157";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));</script>
+
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
https://github.com/taiwanese-work-in/foreign-country/issues/2
resolves #2
## Why is this change necessary?
- Let people to share URLs like `taiwanese-work.in/xxxx`
## How does it address the issue?
- Use dynamic pages and pretty urls according to official document:
  - https://middlemanapp.com/advanced/dynamic_pages/
  - https://middlemanapp.com/advanced/pretty_urls
- Use `yield_content` as a workaround to dynamically change per page
  title according to http://stackoverflow.com/a/12682602

![screen shot 2016-06-14 at 10 41 25 pm](https://cloud.githubusercontent.com/assets/356911/16047081/4448b126-3281-11e6-9cad-0ddb835ead0a.png)
