### PR TITLE
Ignore proxy pages during building

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -16,7 +16,7 @@ page '/*.txt', layout: false
 # proxy "/this-page-has-no-template.html", "/template-file.html", locals: {
 #  which_fake_page: "Rendering a fake page with a local variable" }
 data.countries.each do |slug, country|
-  proxy "/#{slug}/index.html", "/country_template.html", :locals => { country: country }
+  proxy "/#{slug}/index.html", "/country_template.html", :locals => { country: country }, ignore: true
 end
 
 # General configuration


### PR DESCRIPTION
connects to #2
## Why is this change necessary?
- Get errors when `middleman build`

```
undefined local variable or method `country' for
#<#<Class:0x007ff791497d58>:0x007ff79177c348>
/Users/bruce/Projects/taiwanese-work.in/source/country_template.html.erb
:1:in `block in singleton class'
```
## How does it address the issue?
- Add `ignore` option in proxy config.

> In most cases, you will not want to generate the template itself
> without the person_name variable, so you can tell Middleman to
> ignore it https://middlemanapp.com/advanced/dynamic_pages/
