### PR TITLE
Add og:type meta tag

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -4,6 +4,7 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8">
     <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+    <meta content="website" property="og:type">
     <meta property="og:url" content="http://taiwanese-work.in<%= current_page.url %>">
     <meta property="og:title" content="<%= yield_content(:og_title) || "Taiwanese Work in" %>">
     <meta property="og:description" content="<%= yield_content(:og_description) %>">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -4,7 +4,7 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8">
     <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
-    <meta content="website" property="og:type">
+    <meta property="og:type" content="website">
     <meta property="og:url" content="http://taiwanese-work.in<%= current_page.url %>">
     <meta property="og:title" content="<%= yield_content(:og_title) || "Taiwanese Work in" %>">
     <meta property="og:description" content="<%= yield_content(:og_description) %>">


### PR DESCRIPTION
## Why is this change necessary?

From Facebook debugger result:

> og:type is missing. The og:type meta tag is necessary for Facebook to
> render a News Feed story that generates a high click-through rate.
## How does it address the issue?
- Add it as `website`
